### PR TITLE
Theme dark mode fix

### DIFF
--- a/apps/docs/app/themes/ThemeWrapper.tsx
+++ b/apps/docs/app/themes/ThemeWrapper.tsx
@@ -74,7 +74,7 @@ export default function ThemeBuilderWrapper({ children }: PropsWithChildren) {
                 <Button
                   key={c}
                   size="fab"
-                  className={`${COLOR_THEME[c]} min-h-[26px] min-w-[26px] p-1`}
+                  className={`${COLOR_THEME[c]} dark:${COLOR_THEME[c]} min-h-[26px] min-w-[26px] p-1`}
                   onClick={() => changeColor(c as keyof typeof COLOR_THEME)}
                   name={`${c} button`}
                 >

--- a/apps/docs/app/themes/ThemeWrapper.tsx
+++ b/apps/docs/app/themes/ThemeWrapper.tsx
@@ -74,7 +74,7 @@ export default function ThemeBuilderWrapper({ children }: PropsWithChildren) {
                 <Button
                   key={c}
                   size="fab"
-                  className={`${COLOR_THEME[c]} dark:${COLOR_THEME[c]} min-h-[26px] min-w-[26px] p-1`}
+                  className={`${COLOR_THEME[c]} min-h-[26px] min-w-[26px] p-1`}
                   onClick={() => changeColor(c as keyof typeof COLOR_THEME)}
                   name={`${c} button`}
                 >


### PR DESCRIPTION
Issue: 
![image](https://github.com/rhinobase/raftyui/assets/113078518/0cc05398-ab16-4c57-a52a-3c52edc194d2)

Expected: 
![image](https://github.com/rhinobase/raftyui/assets/113078518/83794e13-a703-4731-8481-5c539c3b5cbe)

The themes route Tooltip button was not color-responsive in dark mode. 