### PR TITLE
fix(ui): loading text in button

### DIFF
--- a/packages/ui/src/button/Button.tsx
+++ b/packages/ui/src/button/Button.tsx
@@ -585,6 +585,7 @@ export const Button = forwardRef<HTMLButtonElement, Button>(function Button(
         loading={_loading}
         leftIcon={leftIcon}
         rightIcon={rightIcon}
+        loadingText={loadingText}
       >
         {children}
       </ChildrenRender>


### PR DESCRIPTION
Fixed the issue where loading text prop was not passed in the 'ChildrenRender' sub component